### PR TITLE
Link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Linked Data Fragments website
-This repository contains the source code for [linkeddatafragments.org](http://linkeddatafragments.org).
+This repository contains the source code for [linkeddatafragments.org](https://linkeddatafragments.org).
 
 ## Adding publications
 The publications list is automatically generated from BibTeX. You can add your work on Linked Data Fragments by:
@@ -9,7 +9,7 @@ The publications list is automatically generated from BibTeX. You can add your w
 Please follow the formatting of the other BibTeX entries.
 
 ## Compiling the site locally
-This site uses the [Nanoc static site compiler](http://nanoc.ws/).
+This site uses the [Nanoc static site compiler](https://nanoc.ws/).
 
 ### Preparations
 - Install Ruby >= 2.2.5 and the bundler gem

--- a/content/concept.md
+++ b/content/concept.md
@@ -65,7 +65,7 @@ allows us to visualize different HTTP interfaces for Linked Data _together_.
 **SPARQL endpoints** are easy for clients,
 as they allow highly specific fragment selection.
 However, they also have the highest server cost
-which makes it expensive to host them with [decent availability](http://sw.deri.org/~aidanh/docs/epmonitorISWC.pdf).
+which makes it expensive to host them with [decent availability](http://aidanhogan.com/docs/epmonitorISWC.pdf).
 If you don't want to depend on such an endpoint,
 you download a **data dump**,
 but then you're querying a local source instead of the Web.

--- a/content/concept.md
+++ b/content/concept.md
@@ -7,11 +7,11 @@ order: 3
 Today's Web offers three common ways to access Linked Data:
 
 - A **data dump** contains all triples in an entire dataset
-  _([example](http://downloads.dbpedia.org/3.9/en/))_.
+  _([example](https://downloads.dbpedia.org/3.9/en/))_.
 - A **subject page** contains triples about a specific subject in a dataset
-  _([example](http://dbpedia.org/page/Linked_data))_.
-- A **SPARQL result** contains triples that correspond to a [SPARQL CONSTRUCT](http://www.w3.org/TR/sparql11-query/#construct) query
-  _([example](http://dbpedia.org/sparql?query=PREFIX+dbpedia-owl%3A+%3Chttp%3A%2F%2Fdbpedia.org%2Fontology%2F%3E%0D%0A%0D%0ACONSTRUCT+%7B+%3Fp+a+dbpedia-owl%3AArtist+%7D%0D%0AWHERE+%7B+%3Fp+a+dbpedia-owl%3AArtist+%7D&format=text%2Fturtle))_.
+  _([example](https://dbpedia.org/page/Linked_data))_.
+- A **SPARQL result** contains triples that correspond to a [SPARQL CONSTRUCT](https://www.w3.org/TR/sparql11-query/#construct) query
+  _([example](https://dbpedia.org/sparql?query=PREFIX+dbpedia-owl%3A+%3Chttp%3A%2F%2Fdbpedia.org%2Fontology%2F%3E%0D%0A%0D%0ACONSTRUCT+%7B+%3Fp+a+dbpedia-owl%3AArtist+%7D%0D%0AWHERE+%7B+%3Fp+a+dbpedia-owl%3AArtist+%7D&format=text%2Fturtle))_.
 
 Linked Data Fragments is a conceptual framework that provides a uniform view on all possible interfaces to RDF,
 by observing that each interface partitions a dataset into its own specific kind of _fragments_.
@@ -70,7 +70,7 @@ If you don't want to depend on such an endpoint,
 you download a **data dump**,
 but then you're querying a local source instead of the Web.
 With **subject pages**, servers do minimal effort,
-but clients need to [work hard](http://squin.sourceforge.net/) to solve simple queries.
+but clients need to [work hard](https://squin.sourceforge.net/) to solve simple queries.
 
 Can we **minimize server resource usage**
 while still enabling clients to **query data sources efficiently**?
@@ -86,11 +86,11 @@ One such type is called a **Triple Pattern Fragment**
 It consists of:
 
 - **data** that corresponds to a triple pattern
-  _([example](http://data.linkeddatafragments.org/dbpedia?subject=&predicate=rdf%3Atype&object=dbpedia-owl%3ARestaurant))_.
+  _([example](https://data.linkeddatafragments.org/dbpedia?subject=&predicate=rdf%3Atype&object=dbpedia-owl%3ARestaurant))_.
 - **metadata** that consists of the (approximate) total triple count
-  _([example](http://data.linkeddatafragments.org/dbpedia?subject=&predicate=rdf%3Atype&object=))_.
+  _([example](https://data.linkeddatafragments.org/dbpedia?subject=&predicate=rdf%3Atype&object=))_.
 - **controls** that lead to all other fragments of the same dataset
-  _([example](http://data.linkeddatafragments.org/dbpedia?subject=&predicate=&object=%22John%22%40en))_.
+  _([example](https://data.linkeddatafragments.org/dbpedia?subject=&predicate=&object=%22John%22%40en))_.
 
 Servers that offer such fragments are called
 [**_Triple Pattern Fragments_ servers**](/software/#server).

--- a/content/images/ldf.svg
+++ b/content/images/ldf.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
-<svg version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "https://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="70.9px" height="34px" viewBox="0 0 70.9 34" enable-background="new 0 0 70.9 34" xml:space="preserve">
 <line fill="none" stroke="#808080" stroke-miterlimit="10" stroke-dasharray="1,1" x1="36.4" y1="16.3" x2="43.5" y2="5.9"/>
 <line fill="none" stroke="#808080" stroke-miterlimit="10" stroke-dasharray="1,1" x1="36.9" y1="18.7" x2="43.1" y2="28.3"/>

--- a/content/images/local.svg
+++ b/content/images/local.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
-<svg version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "https://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="70.9px" height="34px" viewBox="0 0 70.9 34" enable-background="new 0 0 70.9 34" xml:space="preserve">
 <line fill="none" stroke="#808080" stroke-width="0.498" stroke-miterlimit="10" stroke-dasharray="1,1" x1="52.1" y1="16.1" x2="11.9" y2="16.4"/>
 <rect x="14.4" y="13.1" fill="#FFFFFF" stroke="#000000" stroke-width="0.398" stroke-miterlimit="10" width="1.8" height="6.3"/>

--- a/content/images/logo.svg
+++ b/content/images/logo.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
-<svg version="1.0" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "https://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="400px" height="220px" viewBox="0 0 400 220" enable-background="new 0 0 400 220" xml:space="preserve">
 <g>
 	<path fill="#1D1D1B" d="M188.8,29.3v99.7h65.4v22.9h-89.9V29.3H188.8z"/>

--- a/content/images/sparql.svg
+++ b/content/images/sparql.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
-<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="70.9px" height="34px">
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "https://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" xmlns="https://www.w3.org/2000/svg" width="70.9px" height="34px">
 <rect x="14.4" y="7.1" fill="#33A237" width="1.9" height="1"/>
 <rect x="41.1" y="7.1" fill="#33A237" width="1.9" height="1"/>
 <rect x="68.3" y="7.1" fill="#33A237" width="1.9" height="1"/>

--- a/content/index.md
+++ b/content/index.md
@@ -16,7 +16,7 @@ moving intelligence from servers to clients.](/concept/)
 [Watch this talk](http://videolectures.net/iswc2014_verborgh_querying_datasets/ "Ruben Verborgh at ISWC2014: Querying Datasets on the Web with High Availability")
 to learn the foundations of Linked Data Fragments.
 
-Try [Comunica](http://comunica.linkeddatafragments.org/), a new Web framework to query Linked Data Fragments.
+Try [Comunica](https://comunica.linkeddatafragments.org/), a new Web framework to query Linked Data Fragments.
 </div>
 
 **A huge amount of Linked Data is available on the Web.**
@@ -78,4 +78,4 @@ Or view some of the 650,000+ datasets out there:
 [browse datasets online](/data/).
 <br>
 See how clients solve SPARQL queries on your data:
-[try a Linked Data Fragments client](http://comunica.linkeddatafragments.org/).
+[try a Linked Data Fragments client](https://comunica.linkeddatafragments.org/).

--- a/content/software.md
+++ b/content/software.md
@@ -16,7 +16,7 @@ This way, servers only need to publish Triple Pattern Fragments of a dataset,
 providing a **scalable yet efficient** way to query Linked Data.
 
 JavaScript
-: [**Try the online demo in your browser**](http://comunica.linkeddatafragments.org/)
+: [**Try the online demo in your browser**](https://comunica.linkeddatafragments.org/)
 : [Comunica](https://github.com/comunica/comunica/) for Node.js and the browser
 : [Client.js](https://github.com/LinkedDataFragments/Client.js) for Node.js and the browser
 : [jQuery Widget](https://github.com/LinkedDataFragments/jQuery-Widget.js) for the browser

--- a/content/specification.md
+++ b/content/specification.md
@@ -8,17 +8,17 @@ The Linked Data Fragments specification is developed
 as part of the [Hydra W3C Community Group](http://www.hydra-cg.com/).
 
 The Hydra project provides technologies for the design of smart APIs and smart clients.
-It consists of the [Hydra Core Vocabulary](http://www.hydra-cg.com/spec/latest/core/),
+It consists of the [Hydra Core Vocabulary](https://www.hydra-cg.com/spec/latest/core/),
 which contains the essential building blocks for machine-accessible hypermedia APIs,
-and [Linked Data Fragments](http://www.hydra-cg.com/spec/latest/linked-data-fragments/),
+and [Linked Data Fragments](https://www.hydra-cg.com/spec/latest/linked-data-fragments/),
 which focus on APIs and clients that enable Web-scale publishing and querying.
 
 ### Current Linked Data Fragments specifications
 
-[Linked Data Fragments — A uniform view on Web interfaces to Linked Data](http://www.hydra-cg.com/spec/latest/linked-data-fragments/)
+[Linked Data Fragments — A uniform view on Web interfaces to Linked Data](https://www.hydra-cg.com/spec/latest/linked-data-fragments/)
 : This document introduces the generic concept of Linked Data Fragments.
 
-[Triple Pattern Fragments — A low-cost, queryable Linked Data Fragments interface](http://www.hydra-cg.com/spec/latest/triple-pattern-fragments/)
+[Triple Pattern Fragments — A low-cost, queryable Linked Data Fragments interface](https://www.hydra-cg.com/spec/latest/triple-pattern-fragments/)
 : This document introduces a specific Linked Data Fragments type
   for low-cost, high-availability querying.
 
@@ -28,5 +28,5 @@ The Linked Data Fragments specifications are still in development.
 Do you have questions, comments or feedback?
 E-mail to [public-linked-data-fragments@w3.org](mailto:public-linked-data-fragments@w3.org).
 
-You can also [join the Hydra W3C Community Group](http://www.w3.org/community/hydra/)
+You can also [join the Hydra W3C Community Group](https://www.w3.org/community/hydra/)
 to contribute to the specifications.

--- a/layouts/default.html.erb
+++ b/layouts/default.html.erb
@@ -5,7 +5,7 @@
   <title><%= @item.path == '/' ? "Linked Data Fragments"
                                : "Linked Data Fragments | #{@item[:title]}" %></title>
   <link rel="stylesheet" href="/styles/main.css">
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400italic,700italic,400,700' rel='stylesheet'>
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400italic,700italic,400,700' rel='stylesheet'>
   <meta name="viewport" content="initial-scale=1">
 </head>
 <body class="<%= @item[:title].downcase.gsub(/[^a-z]/, '') %>">
@@ -19,7 +19,7 @@
                 each do |page|
          %><li<%= @item == page ? ' class="active"' : '' %>><%= link_to(page[:title], page) %></li><%
       end %>
-        <li class="new"><a href="http://comunica.linkeddatafragments.org/">Comunica</a></li>
+        <li class="new"><a href="https://comunica.linkeddatafragments.org/">Comunica</a></li>
     </ul>
   </nav>
   <main>


### PR DESCRIPTION
I did two things: 
* Every link reachable via _https_ is now changed from _http_ to _https_.
* I found a broken link and added a working link to the article (on the author's homepage).