### PR TITLE
Fix controls example to align with text and to be syntactically correct

### DIFF
--- a/content/specification/quad-pattern-fragments/index.html
+++ b/content/specification/quad-pattern-fragments/index.html
@@ -279,7 +279,7 @@ PREFIX sd:    &lt;http://www.w3.org/ns/sparql-service-description#&gt;
       <h3>Data</h3>
       <p>
 		A Quad Pattern Fragment contains all quads of a dataset that matches the fragment's quad pattern selector.
-		These quads SHOULD be consistently ordened such that Quad Pattern Fragments can be paged consistently.
+		These quads SHOULD be consistently ordered such that Quad Pattern Fragments can be paged consistently.
 		Quads SHOULD NOT contain blank nodes, instead these blank nodes SHOULD be <a href="http://www.w3.org/TR/rdf11-concepts/#section-skolemization">skolemized</a>.
       </p>
       <p>
@@ -366,19 +366,19 @@ PREFIX sd:    &lt;http://www.w3.org/ns/sparql-service-description#&gt;
 		This structure MUST either be as the <a href="https://linkeddatafragments.org/specification/triple-pattern-fragments/">Triple Pattern Fragments</a> control form or as the following:
       </p>
 <pre><code>&lt;http://example.org/example#controls&gt;
-      {
+    {
         &lt;http://example.org/example#dataset&gt;
-        void:subset &lt;http://example.org/example?s=http%3A%2F%2Fexample.org%2Ftopic&gt;;
+            void:subset &lt;http://example.org/example?s=http%3A%2F%2Fexample.org%2Ftopic&gt;;
+            hydra:search [
+                hydra:template "http://example.org/example{?s,p,o,g}";
+                hydra:mapping  [ hydra:variable "s"; hydra:property rdf:subject ],
+                               [ hydra:variable "p"; hydra:property rdf:predicate ],
+                               [ hydra:variable "o"; hydra:property rdf:object ],
+                               [ hydra:variable "g"; hydra:property sd:graph ]
+            ].
         &lt;http://example.org/example#controls&gt;
-        foaf:primaryTopic &lt;http://example.org/example#dataset&gt;;
-        hydra:search [
-            hydra:template "http://example.org/example{?s,p,o,g}";
-            hydra:mapping  [ hydra:variable "s"; hydra:property rdf:subject ],
-                           [ hydra:variable "p"; hydra:property rdf:predicate ],
-                           [ hydra:variable "o"; hydra:property rdf:object ],
-                           [ hydra:variable "g"; hydra:property sd:graph ]
-        ].
-      }</code></pre>
+            foaf:primaryTopic &lt;http://example.org/example?s=http%3A%2F%2Fexample.org%2Ftopic&gt;.
+    }</code></pre>
       <p>
         The above snippet assumes the dataset IRI is
         <code>http://example.org/example#dataset</code>,


### PR DESCRIPTION
The `foaf:primaryTopic` triple was inserted in the middle of another triple so needs extracting to the end of the dataset. However I think the object of the triple was incorrect too. There are 2 related sections of text:
> The control form MUST be attached to the dataset since the form filters the dataset, and not the fragment. The fragment MUST be declared as a subset of the dataset such that their relation becomes apparent.

This is a little ambiguous as the mode of attachment is not specified but was perhaps interpreted as
```
<http://example.org/example#controls> foaf:primaryTopic <http://example.org/example#dataset> .
```
However I think that "control form" in this context actually refers to the `hydra:search` node.

The more relevant text is:
> If the RDF syntax supports multiple graphs, control triples MUST be serialized to a non-default graph. This non-default graph MUST be explicitly related to the Quad Pattern Fragment using the foaf:primaryTopic predicate, so clients can interpret what resource this metadata belongs to. This relating triple must be present in controls graph. This graph SHOULD be the same as the graph containing the metadata.

The correct representation of this would appear to be:
```
<http://example.org/example#controls> foaf:primaryTopic <http://example.org/example?s=http%3A%2F%2Fexample.org%2Ftopic> .
```